### PR TITLE
Implement S_CMD_S_PIN_STATE command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The default pin-out is:
 | 2    |    4     | SCK      |
 | 3    |    5     | MOSI     |
 | 4    |    6     | MISO     |
+| 5    |    7     | CRESET   |
 
 ## Usage
 

--- a/main.c
+++ b/main.c
@@ -16,6 +16,7 @@
 #include "pio/pio_spi.h"
 #include "spi.h"
 
+#define PIN_CRESET 5
 #define PIN_MISO 4
 #define PIN_MOSI 3
 #define PIN_SCK 2
@@ -144,10 +145,18 @@ void process(pio_spi_inst_t *spi, int command) {
             putchar(0x0);
             break;
         case S_CMD_S_PIN_STATE:
-            //TODO:
-            getchar();
+	  {
+	    int pin_state = getchar();
+	    if(pin_state == 0) {
+	      // Disable pin drivers
+	      gpio_put(PIN_CRESET, 1);
+	    } else {
+	      // Enable pin drivers
+	      gpio_put(PIN_CRESET, 0);
+	    }
             putchar(S_ACK);
-            break;
+	  }
+	  break;
         default:
             putchar(S_NAK);
     }
@@ -164,7 +173,11 @@ int main() {
     gpio_put(PIN_CS, 1);
     gpio_set_dir(PIN_CS, GPIO_OUT);
 
-
+    // Initialize CRESET
+    gpio_init(PIN_CRESET);
+    gpio_put(PIN_CRESET, 1);
+    gpio_set_dir(PIN_CRESET, GPIO_OUT);
+    
     // We use PIO 1
     pio_spi_inst_t spi = {
             .pio = pio1,

--- a/main.c
+++ b/main.c
@@ -166,6 +166,7 @@ void process(pio_spi_inst_t *spi, int command) {
 	      // Enable pin drivers
 	      gpio_put(PIN_CRESET, 0);
 	    }
+	    asm volatile("nop \n nop \n nop"); // FIXME
             putchar(S_ACK);
 	  }
 	  break;
@@ -188,7 +189,6 @@ int main() {
 
     stdio_set_translate_crlf(&stdio_usb, false);
 
-
     // Initialize CS
     gpio_init(PIN_CS);
     gpio_put(PIN_CS, 1);
@@ -203,19 +203,17 @@ int main() {
     pio_spi_inst_t spi = {
             .pio = pio1,
             .sm = 0,
-            .cs_pin = PIN_CS
+            .pin_cs = PIN_CS,
+	    .pin_sck = PIN_SCK,
+	    .pin_mosi = PIN_MOSI,
+	    .pin_miso = PIN_MISO
     };
 
-    uint offset = pio_add_program(spi.pio, &spi_cpha0_program);
-
-    pio_spi_init(spi.pio, spi.sm, offset,
+    pio_spi_init(&spi,
                  8,       // 8 bits per SPI frame
                  31.25f,  // 1 MHz @ 125 clk_sys
                  false,   // CPHA = 0
-                 false,   // CPOL = 0
-                 PIN_SCK,
-                 PIN_MOSI,
-                 PIN_MISO);
+                 false);  // CPOL = 0
 
     gpio_init(PIN_LED);
     gpio_set_dir(PIN_LED, GPIO_OUT);

--- a/main.c
+++ b/main.c
@@ -63,13 +63,11 @@ static inline void cs_deselect(uint cs_pin) {
 static inline void output_drivers_enable() {
   pio_spi_enable(&spi);
   gpio_put(PIN_CRESET, 0);
-  asm volatile("nop \n nop \n nop"); // FIXME
 }
 
 static inline void output_drivers_disable() {
   gpio_put(PIN_CRESET, 1);
   pio_spi_disable(&spi);
-  asm volatile("nop \n nop \n nop"); // FIXME
 }
 
 uint32_t getu24() {

--- a/pio/pio_spi.c
+++ b/pio/pio_spi.c
@@ -6,6 +6,34 @@
 
 #include "pio_spi.h"
 
+void pio_spi_init(pio_spi_inst_t *spi, uint n_bits, float clkdiv, bool cpha, bool cpol) {
+  spi->prog_offs  = pio_add_program(spi->pio, cpha ? &spi_cpha1_program : &spi_cpha0_program);
+    pio_sm_config c = cpha ? spi_cpha1_program_get_default_config(spi->prog_offs) : spi_cpha0_program_get_default_config(spi->prog_offs);
+    sm_config_set_out_pins(&c, spi->pin_mosi, 1);
+    sm_config_set_in_pins(&c, spi->pin_miso);
+    sm_config_set_sideset_pins(&c, spi->pin_sck);
+    // Only support MSB-first in this example code (shift to left, auto push/pull, threshold=nbits)
+    sm_config_set_out_shift(&c, false, true, n_bits);
+    sm_config_set_in_shift(&c, false, true, n_bits);
+    sm_config_set_clkdiv(&c, clkdiv);
+
+    // MOSI, SCK output are low, MISO is input
+    pio_sm_set_pins_with_mask(spi->pio, spi->sm, 0, (1u << spi->pin_sck) | (1u << spi->pin_mosi));
+    pio_sm_set_pindirs_with_mask(spi->pio, spi->sm, (1u << spi->pin_sck) | (1u << spi->pin_mosi), (1u << spi->pin_sck) | (1u << spi->pin_mosi) | (1u << spi->pin_miso));
+    pio_gpio_init(spi->pio, spi->pin_mosi);
+    pio_gpio_init(spi->pio, spi->pin_miso);
+    pio_gpio_init(spi->pio, spi->pin_sck);
+
+    // The pin muxes can be configured to invert the output (among other things
+    // and this is a cheesy way to get CPOL=1
+    gpio_set_outover(spi->pin_sck, cpol ? GPIO_OVERRIDE_INVERT : GPIO_OVERRIDE_NORMAL);
+    // SPI is synchronous, so bypass input synchroniser to reduce input delay.
+    hw_set_bits(&spi->pio->input_sync_bypass, 1u << spi->pin_miso);
+
+    pio_sm_init(spi->pio, spi->sm, spi->prog_offs, &c);
+    pio_sm_set_enabled(spi->pio, spi->sm, true);
+}
+
 // Just 8 bit functions provided here. The PIO program supports any frame size
 // 1...32, but the software to do the necessary FIFO shuffling is left as an
 // exercise for the reader :)

--- a/pio/pio_spi.h
+++ b/pio/pio_spi.h
@@ -12,7 +12,11 @@
 typedef struct pio_spi_inst {
     PIO pio;
     uint sm;
-    uint cs_pin;
+    uint pin_cs;
+    uint pin_sck;
+    uint pin_mosi;
+    uint pin_miso;
+    uint prog_offs;
 } pio_spi_inst_t;
 
 void pio_spi_write8_blocking(const pio_spi_inst_t *spi, const uint8_t *src, size_t len);
@@ -20,5 +24,7 @@ void pio_spi_write8_blocking(const pio_spi_inst_t *spi, const uint8_t *src, size
 void pio_spi_read8_blocking(const pio_spi_inst_t *spi, uint8_t *dst, size_t len);
 
 void pio_spi_write8_read8_blocking(const pio_spi_inst_t *spi, uint8_t *src, uint8_t *dst, size_t len);
+
+void pio_spi_init(pio_spi_inst_t *spi, uint n_bits, float clkdiv, bool cpha, bool cpol);
 
 #endif

--- a/pio/pio_spi.h
+++ b/pio/pio_spi.h
@@ -12,19 +12,22 @@
 typedef struct pio_spi_inst {
     PIO pio;
     uint sm;
-    uint pin_cs;
     uint pin_sck;
     uint pin_mosi;
     uint pin_miso;
     uint prog_offs;
 } pio_spi_inst_t;
 
+void pio_spi_init(pio_spi_inst_t *spi, uint n_bits, float clkdiv, bool cpha, bool cpol);
+
+void pio_spi_enable(pio_spi_inst_t *spi);
+
+void pio_spi_disable(pio_spi_inst_t *spi);
+
 void pio_spi_write8_blocking(const pio_spi_inst_t *spi, const uint8_t *src, size_t len);
 
 void pio_spi_read8_blocking(const pio_spi_inst_t *spi, uint8_t *dst, size_t len);
 
 void pio_spi_write8_read8_blocking(const pio_spi_inst_t *spi, uint8_t *src, uint8_t *dst, size_t len);
-
-void pio_spi_init(pio_spi_inst_t *spi, uint n_bits, float clkdiv, bool cpha, bool cpol);
 
 #endif

--- a/pio/spi.pio
+++ b/pio/spi.pio
@@ -41,37 +41,6 @@
     mov pins, x side 1 [1] ; Output data, assert SCK (mov pins uses OUT mapping)
     in pins, 1  side 0     ; Input data, deassert SCK
 
-% c-sdk {
-#include "hardware/gpio.h"
-static inline void pio_spi_init(PIO pio, uint sm, uint prog_offs, uint n_bits,
-        float clkdiv, bool cpha, bool cpol, uint pin_sck, uint pin_mosi, uint pin_miso) {
-    pio_sm_config c = cpha ? spi_cpha1_program_get_default_config(prog_offs) : spi_cpha0_program_get_default_config(prog_offs);
-    sm_config_set_out_pins(&c, pin_mosi, 1);
-    sm_config_set_in_pins(&c, pin_miso);
-    sm_config_set_sideset_pins(&c, pin_sck);
-    // Only support MSB-first in this example code (shift to left, auto push/pull, threshold=nbits)
-    sm_config_set_out_shift(&c, false, true, n_bits);
-    sm_config_set_in_shift(&c, false, true, n_bits);
-    sm_config_set_clkdiv(&c, clkdiv);
-
-    // MOSI, SCK output are low, MISO is input
-    pio_sm_set_pins_with_mask(pio, sm, 0, (1u << pin_sck) | (1u << pin_mosi));
-    pio_sm_set_pindirs_with_mask(pio, sm, (1u << pin_sck) | (1u << pin_mosi), (1u << pin_sck) | (1u << pin_mosi) | (1u << pin_miso));
-    pio_gpio_init(pio, pin_mosi);
-    pio_gpio_init(pio, pin_miso);
-    pio_gpio_init(pio, pin_sck);
-
-    // The pin muxes can be configured to invert the output (among other things
-    // and this is a cheesy way to get CPOL=1
-    gpio_set_outover(pin_sck, cpol ? GPIO_OVERRIDE_INVERT : GPIO_OVERRIDE_NORMAL);
-    // SPI is synchronous, so bypass input synchroniser to reduce input delay.
-    hw_set_bits(&pio->input_sync_bypass, 1u << pin_miso);
-
-    pio_sm_init(pio, sm, prog_offs, &c);
-    pio_sm_set_enabled(pio, sm, true);
-}
-%}
-
 ; SPI with Chip Select
 ; -----------------------------------------------------------------------------
 ;


### PR DESCRIPTION
I have an FPGA dev board that has a flash SPI chip. Besides MISO, MOSI, SCK and CS pins it also has a CREST pin that needs to be driven low when you access the flash chip. Currently I have to manually ground CRESET every time I upload a new image to the flash chip.

I thought, I could take advantage of the S_CMD_S_PIN_STATE cmd and drive the CREST pin low on **Output drivers enabled** and high on **Output drivers disabled**.

I've implemented some code to handle the S_CMD_S_PIN_STATE cmd. However, the CREST pin (connected to GP5) does not toggle as expected. Could someone please have a look and tell me if I have missed something?