### PR TITLE
Performance improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,21 @@
+name: build
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y gcc-arm-none-eabi cmake
+      - uses: actions/checkout@v3
+      - run: git clone -b 1.5.0 https://github.com/raspberrypi/pico-sdk
+      - run: cd pico-sdk && git submodule update --init lib/tinyusb
+      - run: cmake -DPICO_SDK_PATH=$PWD/pico-sdk -DPICO_STDIO_USB=ON .
+      - run: make
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pico_serprog
+          path: |
+            README.md
+            COPYING
+            pico_serprog.elf
+            pico_serprog.uf2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+*.bin
+*.dis
+*.elf
+*.elf.map
+*.hex
+*.pio.h
+*.uf2
+CMakeCache.txt
+CMakeCache.txt
+CMakeDoxy*
+CMakeFiles/
+Makefile
+cmake_install.cmake
+elf2uf2/
+generated/
+pico-sdk/
+pioasm/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pico-serprog
 
-This is a very basic flashrom/serprog compatible SPI flash reader/writer for the Raspberry Pi Pico.
+This is a basic flashrom/serprog compatible SPI flash reader/writer for the Raspberry Pi Pico.
 
 It does not require a custom version of flashrom, just drag the compiled uf2 onto your Pico and you're ready to go.
 
@@ -18,7 +18,7 @@ The default pin-out is:
 Dump a flashchip:
 
 ```
-flashrom -p serprog:dev=/dev/ttyACM0:115200 -r foo.bin
+flashrom -p serprog:dev=/dev/ttyACM0:115200,spispeed=12M -r foo.bin
 ```
 
 ## License

--- a/main.c
+++ b/main.c
@@ -16,6 +16,7 @@
 #include "pio/pio_spi.h"
 #include "spi.h"
 
+#define PIN_LED PICO_DEFAULT_LED_PIN
 #define PIN_MISO 4
 #define PIN_MOSI 3
 #define PIN_SCK 2
@@ -193,10 +194,16 @@ int main() {
                  PIN_MOSI,
                  PIN_MISO);
 
+    gpio_init(PIN_LED);
+    gpio_set_dir(PIN_LED, GPIO_OUT);
+
     // Command handling
     while(1) {
         int command = getchar();
+
+        gpio_put(PIN_LED, 1);
         process(&spi, command);
+        gpio_put(PIN_LED, 0);
     }
 
     return 0;

--- a/main.c
+++ b/main.c
@@ -56,6 +56,14 @@ uint32_t getu24() {
     return c1 | (c2<<8) | (c3<<16);
 }
 
+uint32_t getu32() {
+    uint32_t c1 = getchar();
+    uint32_t c2 = getchar();
+    uint32_t c3 = getchar();
+    uint32_t c4 = getchar();
+    return c1 | (c2<<8) | (c3<<16) | (c4<<24);
+}
+
 void putu32(uint32_t d) {
     char buf[4];
     memcpy(buf, &d, 4);
@@ -136,6 +144,8 @@ void process(pio_spi_inst_t *spi, int command) {
             }
             break;
         case S_CMD_S_SPI_FREQ:
+            getu32();
+
             // TODO
             putchar(S_ACK);
             putchar(0x0);

--- a/main.c
+++ b/main.c
@@ -136,14 +136,16 @@ void process(const pio_spi_inst_t *spi, int command) {
                 pio_spi_write8_blocking(spi, write_buffer, wlen);
 
                 putchar(S_ACK);
-                char buf;
-                
-                for(uint32_t i = 0; i < rlen; i++)  {
-                    pio_spi_read8_blocking(spi, &buf, 1);
-                    putchar(buf);
+                uint32_t chunk;
+                char buf[128];
+
+                for(uint32_t i = 0; i < rlen; i += chunk) {
+                    chunk = MIN(rlen - i, sizeof(buf));
+                    pio_spi_read8_blocking(spi, buf, chunk);
+                    fwrite(buf, 1, chunk, stdout);
+                    fflush(stdout);
                 }
 
-                
                 cs_deselect(PIN_CS);
             }
             break;

--- a/main.c
+++ b/main.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include "pico/stdlib.h"
 #include "pico/binary_info.h"
+#include "hardware/clocks.h"
 #include "pio/pio_spi.h"
 #include "spi.h"
 
@@ -38,6 +39,7 @@
   (1 << S_CMD_S_PIN_STATE) \
 )
 
+static uint32_t serprog_spi_init(uint32_t freq);
 
 static inline void cs_select(uint cs_pin) {
     asm volatile("nop \n nop \n nop"); // FIXME
@@ -77,7 +79,7 @@ void putu32(uint32_t d) {
 
 unsigned char write_buffer[4096];
 
-void process(pio_spi_inst_t *spi, int command) {
+void process(const pio_spi_inst_t *spi, int command) {
     switch(command) {
         case S_CMD_NOP:
             putchar(S_ACK);
@@ -146,14 +148,15 @@ void process(pio_spi_inst_t *spi, int command) {
             }
             break;
         case S_CMD_S_SPI_FREQ:
-            getu32();
-
-            // TODO
-            putchar(S_ACK);
-            putchar(0x0);
-            putchar(0x40);
-            putchar(0x0);
-            putchar(0x0);
+            {
+                uint32_t freq = getu32();
+                if (freq >= 1) {
+                    putchar(S_ACK);
+                    putu32(serprog_spi_init(freq));
+                } else {
+                    putchar(S_NAK);
+                }
+            }
             break;
         case S_CMD_S_PIN_STATE:
             //TODO:
@@ -163,6 +166,45 @@ void process(pio_spi_inst_t *spi, int command) {
         default:
             putchar(S_NAK);
     }
+}
+
+// We use PIO 1
+static const pio_spi_inst_t spi = {
+    .pio = pio1,
+    .sm = 0,
+    .cs_pin = PIN_CS
+};
+static uint spi_offset;
+
+static inline float freq_to_clkdiv(uint32_t freq) {
+    float div = clock_get_hz(clk_sys) * 1.0 / (freq * pio_spi_cycles_per_bit);
+
+    if (div < 1.0)
+        div = 1.0;
+    if (div > 65536.0)
+        div = 65536.0;
+
+    return div;
+}
+
+static inline uint32_t clkdiv_to_freq(float div) {
+    return clock_get_hz(clk_sys) / (div * pio_spi_cycles_per_bit);
+}
+
+static uint32_t serprog_spi_init(uint32_t freq) {
+
+    float clkdiv = freq_to_clkdiv(freq);
+
+    pio_spi_init(spi.pio, spi.sm, spi_offset,
+                 8,       // 8 bits per SPI frame
+                 clkdiv,
+                 false,   // CPHA = 0
+                 false,   // CPOL = 0
+                 PIN_SCK,
+                 PIN_MOSI,
+                 PIN_MISO);
+
+    return clkdiv_to_freq(clkdiv);
 }
 
 int main() {
@@ -185,24 +227,8 @@ int main() {
     gpio_put(PIN_CS, 1);
     gpio_set_dir(PIN_CS, GPIO_OUT);
 
-
-    // We use PIO 1
-    pio_spi_inst_t spi = {
-            .pio = pio1,
-            .sm = 0,
-            .cs_pin = PIN_CS
-    };
-
-    uint offset = pio_add_program(spi.pio, &spi_cpha0_program);
-
-    pio_spi_init(spi.pio, spi.sm, offset,
-                 8,       // 8 bits per SPI frame
-                 31.25f,  // 1 MHz @ 125 clk_sys
-                 false,   // CPHA = 0
-                 false,   // CPOL = 0
-                 PIN_SCK,
-                 PIN_MOSI,
-                 PIN_MISO);
+    spi_offset = pio_add_program(spi.pio, &spi_cpha0_program);
+    serprog_spi_init(1000000); // 1 MHz
 
     gpio_init(PIN_LED);
     gpio_set_dir(PIN_LED, GPIO_OUT);

--- a/main.c
+++ b/main.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "pico/stdlib.h"
+#include "pico/binary_info.h"
 #include "pio/pio_spi.h"
 #include "spi.h"
 
@@ -165,6 +166,15 @@ void process(pio_spi_inst_t *spi, int command) {
 }
 
 int main() {
+    // Metadata for picotool
+    bi_decl(bi_program_description("Flashrom/serprog compatible firmware for the Raspberry Pi Pico"));
+    bi_decl(bi_program_url("https://github.com/stacksmashing/pico-serprog"));
+    bi_decl(bi_1pin_with_name(PIN_LED, "LED"));
+    bi_decl(bi_1pin_with_name(PIN_MISO, "MISO"));
+    bi_decl(bi_1pin_with_name(PIN_MOSI, "MOSI"));
+    bi_decl(bi_1pin_with_name(PIN_SCK, "SCK"));
+    bi_decl(bi_1pin_with_name(PIN_CS, "CS#"));
+
     stdio_init_all();
 
     stdio_set_translate_crlf(&stdio_usb, false);

--- a/pio/spi.pio
+++ b/pio/spi.pio
@@ -140,6 +140,9 @@ public entry_point:                 ; Must set X,Y to n-2 before starting!
 
 % c-sdk {
 #include "hardware/gpio.h"
+
+static const int pio_spi_cycles_per_bit = 4;
+
 static inline void pio_spi_cs_init(PIO pio, uint sm, uint prog_offs, uint n_bits, float clkdiv, bool cpha, bool cpol,
         uint pin_sck, uint pin_mosi, uint pin_miso) {
     pio_sm_config c = cpha ? spi_cpha1_cs_program_get_default_config(prog_offs) : spi_cpha0_cs_program_get_default_config(prog_offs);


### PR DESCRIPTION
This PR is a follow-up to #6.

By reconfiguring the PIO/SPI clock rate to frequency requested by flashrom, and filling the USB bulk transfers with more than 1 byte at a time, the net throughput is improved to about 5 Mbit/s (16 MiB are read in 26 seconds).