### PR TITLE
Implement PIN_STATE command: Only set pins to output when requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Dump a flashchip:
 flashrom -p serprog:dev=/dev/ttyACM0:115200,spispeed=12M -r foo.bin
 ```
 
+pico-serprog only switches the pins to output when requested by flashrom. This
+means that you can leave your pico-serprog programmer attached to the flash;
+you don't have to detach it before booting the board that you're programming.
+
+
 ## License
 
 The project is based on the spi_flash example by Raspberry Pi (Trading) Ltd. which is licensed under BSD-3-Clause.

--- a/pio/spi.pio
+++ b/pio/spi.pio
@@ -54,9 +54,9 @@ static inline void pio_spi_init(PIO pio, uint sm, uint prog_offs, uint n_bits,
     sm_config_set_in_shift(&c, false, true, n_bits);
     sm_config_set_clkdiv(&c, clkdiv);
 
-    // MOSI, SCK output are low, MISO is input
+    // MOSI, SCK output are low, MISO is input -- but we start in input mode
     pio_sm_set_pins_with_mask(pio, sm, 0, (1u << pin_sck) | (1u << pin_mosi));
-    pio_sm_set_pindirs_with_mask(pio, sm, (1u << pin_sck) | (1u << pin_mosi), (1u << pin_sck) | (1u << pin_mosi) | (1u << pin_miso));
+    pio_sm_set_pindirs_with_mask(pio, sm, 0, (1u << pin_sck) | (1u << pin_mosi) | (1u << pin_miso));
     pio_gpio_init(pio, pin_mosi);
     pio_gpio_init(pio, pin_miso);
     pio_gpio_init(pio, pin_sck);
@@ -70,6 +70,12 @@ static inline void pio_spi_init(PIO pio, uint sm, uint prog_offs, uint n_bits,
     pio_sm_init(pio, sm, prog_offs, &c);
     pio_sm_set_enabled(pio, sm, true);
 }
+
+static inline void pio_spi_enable_outputs(PIO pio, uint sm, bool output, uint pin_sck, uint pin_mosi, uint pin_miso) {
+    uint mask = output? (1u << pin_sck) | (1u << pin_mosi) : 0;
+    pio_sm_set_pindirs_with_mask(pio, sm, mask, (1u << pin_sck) | (1u << pin_mosi) | (1u << pin_miso));
+}
+
 %}
 
 ; SPI with Chip Select


### PR DESCRIPTION
This has the advantage that the pico-serprog can stay attached to the board even while a CPU etc. runs on the board and uses the flash.

NOTE (cc @dan-corneanu): This doesn't not implement the RESET as in https://github.com/stacksmashing/pico-serprog/pull/4 , but RESET pin support could be implemented on top of it.